### PR TITLE
[#1976/wcharibo]여행 가자

### DIFF
--- a/wcharibo/week1/250917/BOJ_1976.java
+++ b/wcharibo/week1/250917/BOJ_1976.java
@@ -1,0 +1,56 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ_1976 {
+	static int[] set;
+	
+	static void union(int i, int j) {
+		int pi = find(i);
+		int pj = find(j);
+		
+		if(pi == pj) return;
+		
+		set[pj] = pi;
+	}
+	
+	static int find(int i) {
+		if(set[i] == i) return set[i];
+		
+		return set[i] = find(set[i]);
+	}
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		
+		int N = Integer.parseInt(br.readLine());
+		int M = Integer.parseInt(br.readLine());
+		
+		set = new int[N];
+		
+		for(int i = 0; i < N; i++) set[i] = i;
+		
+		for(int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());	
+			for(int j = 0; j < N; j++) {
+				if(Integer.parseInt(st.nextToken()) == 1) {
+					union(i, j);
+				}
+			}
+		}
+		
+		st = new StringTokenizer(br.readLine());
+		
+		int flag = set[Integer.parseInt(st.nextToken()) - 1]; 
+		
+		for(int i = 1; i < M; i++) {
+			if(flag != find(Integer.parseInt(st.nextToken()) - 1)) {
+				System.out.println("NO");
+				return;
+			}
+		}
+		
+		System.out.println("YES");
+		
+	}	
+}


### PR DESCRIPTION
# 여행 가자

## 📋 문제 정보
- **플랫폼**: Baekjoon
- **문제 번호**: 1976
- **난이도**: Gold 4

---

## 🎯 문제 접근 방식

- **문제 분석 :**
그래프 간선을 입력받고 방문해야하는 도시들이 하나의 그래프에 속하는지 확인하는 문제였습니다.
도시의 수는 200개, 여행 계획에 포함되는 도시의 개수는 1000개이므로 중복된 도시가 있을 것이고 순서를 고려해야하나 했지만,
해당 문제에서는 순서 고려할 필요 없이 그래프에 포함되기만 하면 주어진 조건을 만족하기 때문에
처음에는 **DFS**로 여행계획의 첫 도시를 시작점으로 그래프 탐색을 해줄까 했습니다.
하지만, 결국 여행계획의 도시들이 하나의 그래프로 이루어진거만 확인하는 것이라면 **Union-Find** 알고리즘을 사용할 수 있겠다고 생각하고
풀이 진행했습니다.

- **사용할 알고리즘/자료구조 :**
Union-Find

---

## 📊 복잡도 분석

- **O(N^2)**
  - N^2번 입력을 받으며 find 두번 해준 뒤에 M번 반복하므로 (N^2 x 2 x a(N) ) + M
  - 여기서 a(N)의 a는 아커만 함수를 의미하고 아커만 함수는 상수의 시간 복잡도가진다고 합니다.
---

## ⚡ 메모리/실행시간

### 결과
- **메모리**: 16,184KB
- **실행시간**: 112ms

### 기타 및 참고사항

- union 함수 동작하면서 find로 경로 압축하기 때문에 여행 계획에 포함되는지 확인하는 
```java
for(int i = 1; i < M; i++) {
	if(flag != find(Integer.parseInt(st.nextToken()) - 1)) {
		System.out.println("NO");
		return;
	}
}
``` 
위의 코드에서 find 대신 set의 값을 바로 비교해도 될 것이라고 생각했는 데, 그러면 fail이 떴습니다.
미처 경로 압축되지 않은 결과가 있을 수 있어서 그런 것 같습니다.
하나의 union인지 확인하는 연산을 하려는 경우에는 반드시 find를 이용해서 root 비교하여 확인해야겠습니다.