### PR TITLE
[#4179/jaeeyong] 불!

### DIFF
--- a/jaeeyong/week1/0918/BOJ_4179.java
+++ b/jaeeyong/week1/0918/BOJ_4179.java
@@ -1,0 +1,90 @@
+/**
+ * @Link https://www.acmicpc.net/problem/4179
+ * @RunningTime 312 ms
+ * @Memory 51064 KB
+ * @Stratgy 너비 우선 탐색 (BFS)
+ * - 하나의 큐에 불과 지훈의 위치를 함께 넣어 BFS를 실행합니다. 불을 먼저 큐에 넣어, 매 시간(너비)마다 불의 확산이 지훈의 이동보다 먼저 처리되도록 하여 탈출 가능 여부와 최소 시간을 탐색합니다.
+ */
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		int R = Integer.parseInt(st.nextToken()); // 행
+		int C = Integer.parseInt(st.nextToken()); // 열
+		Queue<int[]> queue = new ArrayDeque<>(); // BFS를 위한 큐
+		
+		// visited 배열: 0(미방문), 1(벽/불), >1(지훈이 방문한 시간)
+		int[][] visited = new int[R + 2][C + 2];
+		
+		// 맵 주위에 벽을 한 겹 둘러서 탈출 조건을 쉽게 처리
+		for (int i = 0; i < R + 2; i++) {
+			visited[i][0] = visited[i][C + 1] = 1;
+		}
+		for (int i = 0; i < C + 2; i++) {
+			visited[0][i] = visited[R + 1][i] = 1;
+		}
+		
+		int[] J = new int[2]; // 지훈이의 초기 위치
+		// 맵 정보 입력 및 초기 설정
+		for (int i = 1; i < R + 1; i++) {
+			String str = br.readLine();
+			for (int j = 1; j < C + 1; j++) {
+				char cur = str.charAt(j - 1);
+				if (cur == '#') // 벽
+					visited[i][j] = 1;
+				else if (cur == 'J') { // 지훈
+					J[0] = i;
+					J[1] = j;
+					visited[i][j] = 1; // 시작 시간은 1분
+				} else if (cur == 'F') { // 불
+					queue.offer(new int[] { i, j, 1 }); // 큐에 추가 (타입 1: 불)
+					visited[i][j] = 1;
+				}
+			}
+		}
+		// 불을 먼저 모두 넣은 후, 지훈이를 마지막에 넣어 같은 레벨에서 불이 먼저 처리되도록 함
+		queue.offer(new int[] { J[0], J[1], 0 }); // 큐에 추가 (타입 0: 지훈)
+
+		int[][] dir = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } }; // 상하좌우
+
+		while (!queue.isEmpty()) {
+			int[] current = queue.poll();
+			
+			// 현재 위치가 지훈이이고, 맵의 가장자리에 도달했다면 탈출 성공
+			if (current[2] == 0 && (current[0] == 1 || current[0] == R || current[1] == 1 || current[1] == C)) {
+				System.out.println(visited[current[0]][current[1]]);
+				return;
+			}
+			
+			// 상하좌우 4방향으로 확산/이동
+			for (int d = 0; d < 4; d++) {
+				int nr = current[0] + dir[d][0];
+				int nc = current[1] + dir[d][1];
+
+				// 현재 탐색 대상이 '불'인 경우
+				if (current[2] == 1) {
+					// 다음 칸이 아직 불타지 않은 빈 공간이라면
+					if (visited[nr][nc] == 0) {
+						visited[nr][nc] = 1; // 불타는 것으로 처리
+						queue.offer(new int[] { nr, nc, current[2] }); // 다음 확산을 위해 큐에 추가
+					}
+				// 현재 탐색 대상이 '지훈'인 경우
+				} else if (current[2] == 0) {
+					// 다음 칸에 처음 방문하거나, 더 빠른 시간에 도달할 수 있는 경우
+					if (visited[nr][nc] == 0 || visited[nr][nc] > visited[current[0]][current[1]] + 1) {
+						visited[nr][nc] = visited[current[0]][current[1]] + 1; // 시간 기록
+						queue.offer(new int[] { nr, nc, current[2] }); // 다음 이동을 위해 큐에 추가
+					}
+				}
+			}
+		}
+		// 큐가 비었는데 탈출하지 못했다면 불가능
+		System.out.println("IMPOSSIBLE");
+	}
+}


### PR DESCRIPTION

# 문제 제목

## 📋 문제 정보
- **플랫폼**: Baekjoon
- **문제 번호**: 1000
- **난이도**: Gold 4

---

## 🎯 문제 접근 방식

- **문제 분석 :**
불과 지훈이 모두 지나갈 수 있는 공간만 지나갈 수 있으며, 불은 한 번에 상하좌우로 번지고, 지훈이는 한 번에 한 칸을 이동할 수 있습니다. 이 때 지훈이가 미로의 가장자리에 도달하는 최소 시간(최단 경로)을 구하는 문제이므로, 완전 탐색: BFS를 이용하기로 결정했습니다.

- **사용할 알고리즘/자료구조 :**
핵심은 같은 시간대에 지훈이의 이동보다 불의 확산이 먼저 일어나야 한다는 점입니다. BFS를 하기 위해 필요한 자료구조인 Queue의 특징(이게 결국 BFS의 특징이기도 합니다.)을 잘 생각해보면, 초기 큐에 입력하는 불과 지훈이의 순서가 각 시간마다 보장됨을 알 수 있습니다.
BFS는 레벨별로 탐색을 진행하는 중복 제외 완전 탐색 방법입니다. 여기서 하나의 레벨은 동일한 시간을 의미하게 됩니다. 현재 시간에 해당하는 모든 노드를 전부 탐색하고 큐에 넣은 뒤에야 다음 시간에 해당하는 노드들을 탐색하게 됩니다.
따라서, 가장 먼저 도착하는 지훈이의 탈출 경로가 곧 최소 시간에 도착하는 최단 경로임을 보장할 수 있습니다.
이러한 특징을 이용하여 단일 큐만을 이용하여 불과 지훈이의 이동 경로를 탐색했고, 지훈이가 도착하는 첫 번째 경로를 찾음과 동시에 탐색을 종료하고 결과값을 출력하였습니다.

---

## 📊 복잡도 분석

- $$O(R×C)$$
BFS를 사용하며, 미로의 모든 칸(R x C)은 불 또는 지훈이에 의해 최대 한 번씩만 방문됩니다. 따라서 시간 복잡도는 미로의 크기에 비례하는 $$O(R×C)$$가 됩니다.

---

## ⚡ 메모리/실행시간

### 결과
- **메모리**: 51064KB
- **실행시간**: 312ms

### 기타 및 참고사항
- 이전에 풀었던 SWEA의 '오! 나의 여신님' 문제와 같이, 두 종류의 객체(플레이어와 방해물)가 동시에 확산/이동하는 유사한 유형이었기 때문에 BFS를 활용하여 불을 먼저 처리하는 접근법을 빠르게 떠올릴 수 있었습니다.