### PR TITLE
[#4179/wcharibo]불!

### DIFF
--- a/wcharibo/week1/250918/BOJ_4179.java
+++ b/wcharibo/week1/250918/BOJ_4179.java
@@ -1,0 +1,140 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ_4179 {
+	//bfs에 담을 객체 생성 fire는 불인지 판단, dist는 bfs수행시에 불은 map에서 가지고 있는 값이 무엇이든 벽만 아니라면 확장되기 때문에 필요한 거리 값이 소실되는 경우가 발생해서 지훈이 객체의 경우에는 dist값을 저장해줌 
+	static class MovingObject {
+		boolean fire;
+		int r;
+		int c;
+		int dist;
+		// 불 
+		MovingObject(boolean fire, int x, int y) {
+			this.fire = fire;
+			this.r = x;
+			this.c = y;
+		}
+		// 지훈이 
+		MovingObject(boolean fire, int x, int y, int dist) {
+			this.fire = fire;
+			this.r = x;
+			this.c = y;
+			this.dist = dist;
+		}
+		
+		Pair getPair() {
+			return new Pair(this.r, this.c);
+		}
+	}
+	
+	//행과 열의 index를 저장하기 위한 클래
+	static class Pair{
+		int r;
+		int c;
+		
+		Pair(int x, int y){
+			this.r = x;
+			this.c = y;
+		}
+		
+		int x() {
+			return this.r;
+		}
+		
+		int y() {
+			return this.c;
+		}
+		//아래의 코드는 set에서 contains연산 수행시에 new Pair(x,y)를 인자값으로 주면 다른 hashCode를 가지는 별도의 instance이기 때문에 해당 (x,y)가 출구에 해당하는 위치여도 다르다고 판단하기 때문에
+		//그 문제를 해결하기 위한 코드 
+		@Override
+	    public boolean equals(Object obj) {
+			Pair other = (Pair) obj;
+	        return this.r == other.r && this.c == other.c;
+	    }
+		
+		@Override
+		public int hashCode() {
+			return Objects.hash(r,c);
+		}
+	}
+
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int R = Integer.parseInt(st.nextToken());
+		int C = Integer.parseInt(st.nextToken());
+		
+		
+		//벽의 유무와 불의 유무로 다음 칸이 이동할 수 있는지 확인하기 위한 2차원 배
+		int[][] map = new int[R][C];
+		//4방 탐색 
+		int dirs[][] = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+		// 출구를 저장할 set, 검색이 잦을 것 같아서 hashSet 사
+		Set<Pair> exits = new HashSet<>();
+		// BFS수행할 q
+		Queue<MovingObject> q = new ArrayDeque<>();
+		// 입력 처리 시에 저장할 시작
+		MovingObject start = null;
+		
+		
+		// 입력받으면서 필요한 정보 저장
+		for (int i = 0; i < R; i++) {
+			String str = br.readLine();
+			for (int j = 0; j < C; j++) {
+				// 벽이면 -1
+				if (str.charAt(j) == '#') {
+					map[i][j] = -1;
+				//불이면 큐에 미리 추가하고 -1
+				} else if (str.charAt(j) == 'F') {
+					q.add(new MovingObject(true, i, j));
+					map[i][j] = -1;
+				//시작점은 큐에서 불의 탐색 다음에 탐색하도록 불의 시작점을 모두 큐에 넣은 뒤에 삽입하기 위해 저장 
+				} else if (str.charAt(j) == 'J') {
+					start = new MovingObject(false, i, j, 0);
+					//시작점이 출구와 인접하게 주어지는 경우도 있
+					if(i==0 || j ==0 || i == R-1 || j == C-1) {
+						exits.add(new Pair(i,j));
+					}
+				// map의 가장 자리이면 출구로 추
+				} else if(i==0 || j ==0 || i == R-1 || j == C-1) {
+					exits.add(new Pair(i,j));
+				}
+			}
+		}
+		//시작점 q에 추가 
+		q.add(start);
+
+		while (!q.isEmpty()) {
+			MovingObject cur = q.poll();
+			
+			//지훈이가 출구에 도착했다면 
+			if(!cur.fire) {
+				if(exits.contains(new Pair(cur.r, cur.c))){
+					System.out.println(cur.dist +1);
+					return;
+				}
+			}
+			
+			for(int i = 0; i < 4; i++) {
+				int nr = cur.r + dirs[i][0];
+				int nc = cur.c + dirs[i][1];
+				
+				if(0 <= nr && nr < R && 0 <= nc && nc < C) {
+					//불이라면 벽이 아닌 모든 경우에 map을 -1 로 변경하고 q에 추가  
+					if(cur.fire && map[nr][nc] >= 0) {
+						q.add(new MovingObject( cur.fire, nr, nc));
+						map[nr][nc] = -1;
+					//지훈이라면 map이 0인 경우에만 q에 추가 
+					}else if(!cur.fire && map[nr][nc] == 0) {
+						map[nr][nc] = cur.dist + 1;
+						q.add(new MovingObject(cur.fire, nr, nc , map[nr][nc]));
+					}
+				}
+			}
+			
+		}
+		// 지훈이가 출구에 도착하는 경우가 없다면 
+		System.out.println("IMPOSSIBLE");
+	}
+}


### PR DESCRIPTION

# 문제 제목

## 📋 문제 정보
- **플랫폼**: Baekjoon
- **문제 번호**: 4179
- **난이도**: Gold 3

---

## 🎯 문제 접근 방식

- **문제 분석 :**
  - 출발점은 정해져 있지만 도착점은 정해져있지 않은 문제였습니다.
  도착점을 어떻게 관리할까 하다가 도착점에 해당하는 조건을 만족하는 경우에 도착점이라고 판단하면 되겠다고 생각했습니다.
  그래서 입력시에 도착점에 해당하는 '미로의 가장자리'의 경우에 도착점이라고 저장해 주었습니다.
  도착점에 대한 검색이 빈번할 것 같아서 HashSet 사용해서 검색의 시간 복잡도를 줄일 수 있겠다고 생각했습니다.
  - 결국 도착점이 정해지지 않은 최단거리를 찾아라가 문제의 핵심이라고 생각했고 BFS로 해결할 수 있다고 판단했습니다.
  - BFS를 사용한다면 발생할 수 있는 문제점은 불과 지훈이를 동시에 이동시키는 것이라고 생각했습니다.
  하나의 queue만 사용하고 불을 먼저 확산시킨 뒤에 이동 가능한 경로로만 지훈이를 이동시킨다면 문제를 해결할 수 있다고 판단했습니다.
  그래서 불을 먼저 queue에 넣고 지훈이를 그 뒤에 넣은 채로 BFS탐색을 시작했습니다.
  BFS를 돌며 지훈이가 출구에 도착하는 시점에 +1 해주어서 결과를 출력했습니다. 

- **사용할 알고리즘/자료구조 :**
BFS, HashSet
---

## 📊 복잡도 분석

- **O(N^2)**

---

## ⚡ 메모리/실행시간

### 결과
- **메모리**: 62,640KB
- **실행시간**: 500ms

### 기타 및 참고사항
HashSet의 contains이용해서 검색을 진행하는 경우 해당 함수에 인자로 전달하는 객체가 Reference 객체일 때, 그 객체가 갖는 값이 같아도 HashCode값이 달라져서 다른 객체라고 판단합니다.
따라서 같은 값을 가지는 경우에 같은 객체라고 판단하게 하고 싶다면 코드의 Pair클래스에서 한 것처럼 equals와 hashCode를 override해서 재정의 해주어야 합니다. 
근데 또 어지럽게 TreeSet이나 TreeMap의 경우에는 값이 같으면 같은 객체라고 인식하는 걸로 알고 있습니다. 아마 TreeSet의 경우에는 사용자가 직접 비교 연산을 지정해주고 그걸 기준으로 정렬을 하기 때문이지 않을까 싶습니다.