### PR TITLE
[#2887/wcharibo] 행성 터널

### DIFF
--- a/wcharibo/week1/0919/BOJ_2887.java
+++ b/wcharibo/week1/0919/BOJ_2887.java
@@ -1,0 +1,106 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ_2887 {
+	// 유니온파인드에 사용할 배열 
+	static int[] sets;
+	
+	//행성 인덱스와 좌표를 저장할 클래스 
+	static class Planet implements Comparable<Planet> {
+		int l;
+		int idx;
+
+		Planet(int l, int idx) {
+			this.l = l;
+			this.idx = idx;
+		}
+
+		@Override
+		public int compareTo(Main.Planet o) {
+			return this.l - o.l;
+		}
+	}
+
+	//간선 클래스 
+	static class Edge implements Comparable<Edge> {
+		int start;
+		int end;
+		int fare;
+
+		Edge(int start, int end, int fare) {
+			this.start = start;
+			this.end = end;
+			this.fare = fare;
+		}
+
+		@Override
+		public int compareTo(Main.Edge o) {
+			return this.fare - o.fare;
+		}
+
+	}
+	
+	//union find
+	static int find(int a) {
+		if (sets[a] == a)
+			return a;
+		return sets[a] = find(sets[a]);
+	}
+
+	static boolean union(int a, int b) {
+		int pa = find(a);
+		int pb = find(b);
+
+		if (pa == pb)
+			return false;
+
+		sets[pb] = pa;
+		return true;
+	}
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int N = Integer.parseInt(br.readLine());
+		int result = 0;
+
+		Planet[][] galaxy = new Planet[3][N];
+		sets = new int[N];
+		
+		for (int i = 0; i < N; i++) {
+			//유니온파인드 배열 초기화 
+			sets[i] = i;
+			st = new StringTokenizer(br.readLine());
+			//행성들의 3차원 좌표들을 각각 저장하기 
+			for(int j = 0; j < 3; j++) {
+				galaxy[j][i] = new Planet(Integer.parseInt(st.nextToken()), i);
+			}
+		}
+		
+		//인접한 행성들만 보기위해 정렬 
+		for(int i = 0; i < 3; i++) {
+			Arrays.sort(galaxy[i]);
+		}
+
+		PriorityQueue<Edge> pq = new PriorityQueue<Edge>();
+		
+		//인접한 행성들간의 거리만 pq에 삽입 
+		for (int i = 1; i < N; i++) {
+			for(int j = 0; j < 3; j++) {
+				pq.add(new Edge(galaxy[j][i-1].idx, galaxy[j][i].idx, galaxy[j][i].l - galaxy[j][i-1].l));
+			}
+		}
+		
+		//크루스칼 
+		while(!pq.isEmpty()) {
+			Edge cur = pq.poll();
+			
+			if(union(cur.start, cur.end)) {
+				result+=cur.fare;
+			}
+		}
+		
+
+		System.out.println(result);
+	}
+}


### PR DESCRIPTION

# 문제 제목

## 📋 문제 정보
- **플랫폼**: Baekjoon
- **문제 번호**: 2887
- **난이도**: Platinum 5

---

## 🎯 문제 접근 방식

- **문제 분석 :**
일전에 풀었던 하나로 문제와 같은 유형인 MST문제였습니다. 
다만 3차원 좌표와 같은 평면상의 비교로만 거리를 계산한다는 점이 달랐습니다. 
  - 시간 초과 가능성
  문제에서 주어진 행성의 개수가 10만개여서 각각의 행성끼리의 간선을 생성해서 크루스칼 혹은 프림을 적용할 수 없었습니다.
  - 인접한 행성만 고려하기
  문제에서 주어진 거리 계산의 형태를 이용해서 인접한 행성과의 간선들만을 고려한 알고리즘을 생성해서 풀 수 있었습니다.
  각각의 평면상의 좌표들을 정렬해서 각 평면상에서 인접한 행성들끼리의 간선만 우선순위 큐에 저장하고 크루스칼 알고리즘 적용했습니다.

- **사용할 알고리즘/자료구조 :**
크루스칼

---

## 📊 복잡도 분석

- **O(ElogE)**

---

## ⚡ 메모리/실행시간

### 결과
- **메모리**: 80,952KB
- **실행시간**: 1336ms

### 기타 및 참고사항
처음에는 행성 간의 거리가 0이 되면 탐색을 멈추는 방식으로 최적화한 프림 알고리즘으로 풀이했으나 시간 초과가 발생했고, 다른 사람의 풀이를 참고해서 평면끼리의 비교와 인접한 행성만 고려하는 방식을 찾을 수 있었습니다. 