### PR TITLE
[#1976/wcharibo] 욕심쟁이 판다

### DIFF
--- a/wcharibo/week2/0924/BOJ_1976.java
+++ b/wcharibo/week2/0924/BOJ_1976.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_1976 {
+	static int n;
+	static int[][] forest, dist;
+	static int[][] dirs = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+	
+	public static int dfs(int i , int j) {
+		int cur = forest[i][j];
+		int candidates[] = new int[4];
+		
+		if(dist[i][j] != 0) return dist[i][j];
+		
+		for(int dir = 0; dir < 4; dir++) {
+			int ni = i + dirs[dir][0];
+			int nj = j + dirs[dir][1];
+//			System.out.println(i + "    " + j);
+			if(0 <= ni && ni < n && 0 <= nj && nj < n && forest[ni][nj] > cur) {
+				if(dist[ni][nj] != 0) {
+					candidates[dir] = dist[ni][nj] + 1;
+					continue;
+				}
+				
+				candidates[dir] = dfs(ni, nj);
+			}			
+		}
+		
+		int max = Integer.MIN_VALUE;
+		for(int cnt = 0; cnt < candidates.length; cnt++) {
+			max = Math.max(max, candidates[cnt]);
+		}
+		
+		dist[i][j] = max;
+		
+		return dist[i][j]+1;
+	}
+	
+	
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		n = Integer.parseInt(br.readLine());
+
+		forest = new int[n][n];
+
+		for (int i = 0; i < n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < n; j++) {
+				forest[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		dist = new int[n][n];
+		
+		int result = Integer.MIN_VALUE;
+		
+		for(int i = 0; i < n; i++) {
+			for(int j = 0; j < n; j++) {
+				dfs(i, j);
+				
+				result = Math.max(result, dist[i][j]);
+			}
+		}
+		
+		System.out.println(result+1);
+	}
+}
+

--- a/wcharibo/week2/0925/BOJ_11000.java
+++ b/wcharibo/week2/0925/BOJ_11000.java
@@ -1,0 +1,43 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_11000 {	
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int n = Integer.parseInt(br.readLine());
+		PriorityQueue<Integer> start = new PriorityQueue<>();
+		PriorityQueue<Integer> end = new PriorityQueue<>();
+		
+		for(int i = 0; i < n; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			start.add(Integer.parseInt(st.nextToken()));
+			end.add(Integer.parseInt(st.nextToken()));
+		}
+	
+		int room = 0;
+		int result = 0;
+		
+		while(!start.isEmpty()) {
+			if(start.peek() < end.peek()) {
+				start.poll();
+				room++;
+			}else if(start.peek() == end.peek()) {
+				start.poll();
+				end.poll();
+			}else{
+				end.poll();
+				room--;
+			}
+			result = Math.max(result, room);
+		}
+		
+		System.out.println(result);
+	}
+}
+


### PR DESCRIPTION
# 욕심쟁이 판다

## 📋 문제 정보
- **플랫폼**: Baekjoon
- **문제 번호**: 1976
- **난이도**: Gold 3

---

## 🎯 문제 접근 방식

- **문제 분석 :**
일전의 swea 등산로 문제와 유사하다고 판단했어서 dfs로 접근할 수 있겠다고 생각했습니다. 일전 문제와 해당 문제가 다른 점은 모든 위치가 시작점이 될 수 있다는 것입니다.
해당 문제는 대나무의 양을 변화시키는 조건이 없었기 때문에 dp가 가능할 것 같다는 성훈이의 제안으로 dfs 결과를 저장하고 dfs를 이미 마친 칸을 만나면 그 값을 사용하는 방식으로 구현했습니다.

- **사용할 알고리즘/자료구조 :**
dfs + dp

---

## 📊 복잡도 분석

- **O(N^2)**
메모이제이션 덕분에 dfs를 깊게 탐색하는 건 한번만 수행하게 돼서 dfs에 대한 시간 복잡도는 상수시간으로 수렴하고 대나무 숲의 모든 지점을 탐색하는 2차원 탐색이 가장 큰 시간복잡도를 차지하므로 O(N^2) 입니다. (chatgpt피셜)

---

## ⚡ 메모리/실행시간

### 결과
- **메모리**: 58,532KB
- **실행시간**: 424ms

### 기타 및 참고사항